### PR TITLE
Call iwconfig with full path instead of assuming it is on the $PATH.

### DIFF
--- a/wlan_pwr
+++ b/wlan_pwr
@@ -23,6 +23,6 @@ if [ ! -x /sbin/iwconfig ]; then
 	exit 0
 fi
 
-iwconfig $IFACE power off
+/sbin/iwconfig $IFACE power off
 
 exit 0


### PR DESCRIPTION
Didn't run into an actual issue with this but a stylistic and best practice, especially when the check above does a check at the full path.  Preventative push in case someone finds a way to break their $PATH.
